### PR TITLE
fix typo in options

### DIFF
--- a/autoscale.rb
+++ b/autoscale.rb
@@ -81,7 +81,7 @@ class Optparser
       opts.on("--intervals-past-threshold Integer", Integer, "An app won't be" +
               " scaled until it's past it's threshold for this many intervals (Default: " +
               "#{options.intervals_past_threshold})") do |value|
-        options.threshold_instances = value
+        options.intervals_past_threshold = value
       end
 
       opts.separator ""


### PR DESCRIPTION
the option options.threshold_instances was getting overwrote by options.intervals_past_threshold value and intervals_past_threshold was never getting set except for the default.
