### PR TITLE
Use shift instead of rotate+pop

### DIFF
--- a/autoscale.rb
+++ b/autoscale.rb
@@ -240,8 +240,7 @@ class Autoscale
   def aggregate_haproxy_data(haproxy_data)
     @apps.each do |app,data|
       if data[:rate].length >= @options.samples
-        data[:rate].rotate!
-        data[:rate].pop
+        data[:rate].shift
       end
       rate = 0
       haproxy_data.each do |d|


### PR DESCRIPTION
The current logic rotates the whole array and performs a pop. Pop removes the last element of the array.

As an alternative, use Array#shift. It removes the first element of the array without the need to rotate all the elements.

As always, Ruby code is tricky. Please let me know if I'm missing something.
