### PR TITLE
Use backend stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Specific options:
                                      Scaling will occur when the target number of instances differs from the actual number by at least this amount (Default: 3)
         --max-instances Integer      Maximum number of instances an app may be scaled to (Default: a huge number)
         --min-instances Integer      Minimum number of instances an app must have (Default: 1)
+        --haproxy_frontend_or_backend String
+                                     If we have to monitor stats from backends (option BACKEND) or frontends (option FRONTEND) (Default: FRONTEND)
 
 Common options:
     -h, --help                       Show this message

--- a/autoscale.rb
+++ b/autoscale.rb
@@ -35,6 +35,7 @@ class Optparser
     options.haproxyCredentials = []
     options.max_instances = Integer::MAX
     options.min_instances = 1
+    options.haproxy_frontend_or_backend = "FRONTEND"
 
     opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: autoscale.rb [options]"
@@ -107,6 +108,12 @@ class Optparser
               "of instances an app must have (Default: " +
               "#{options.min_instances})") do |value|
         options.min_instances = value
+      end
+
+      opts.on("--haproxy_frontend_or_backend String", String, "If we have " +
+              "to monitor backend or frontends in haproxy (Default: " +
+              "#{options.haproxy_frontend_or_backend})") do |value|
+        options.haproxy_frontend_or_backend = value
       end
 
       opts.separator ""
@@ -205,7 +212,7 @@ class Autoscale
     header_labels
   end
 
-  def parse_haproxy_frontends(csv, header_labels)
+  def parse_haproxy_zones(csv, header_labels)
     csv = csv.select do |line|
       # Drop all lines which are empty or begin with # or empty
       !line.match(/^\s*#/) && !line.match(/^\s*$/)
@@ -213,18 +220,18 @@ class Autoscale
     samples = csv.map do |line|
       line.split(/,/)
     end.select do |line|
-      line[1].match('FRONTEND')
+      line[1].match(@options.haproxy_frontend_or_backend)
     end
 
-    frontends = {}
+    zones = {}
     samples.each do |sample|
       data = {}
       header_labels.each do |i,label|
         data[label.to_sym] = sample[i]
       end
-      frontends[sample[0]] = data
+      zones[sample[0]] = data
     end
-    frontends
+    zones
   end
 
   def sample(haproxy)
@@ -242,14 +249,14 @@ class Autoscale
     csv = res.body.split(/\r?\n/)
 
     header_labels = parse_haproxy_header_labels(csv)
-    frontends = parse_haproxy_frontends(csv, header_labels)
+    zones = parse_haproxy_zones(csv, header_labels)
 
     # Now we've got all the frontend data sampled in `frontends`
-    frontends = frontends.select do |name|
+    zones = zones.select do |name|
       @options.apps.include?(name)
     end
 
-    frontends
+    zones
   end
 
   def aggregate_haproxy_data(haproxy_data)


### PR DESCRIPTION
Hi,

I've modified the marathon-lb-autoscale script, adding an option to use backend stats instead of the frontend stats, for those services that you don't use against service port, but as vhosts in the default http and https frontend.

I hope you find it useful.

Jose Maria.